### PR TITLE
Added MemoryMap

### DIFF
--- a/C64/Source/C64.pas
+++ b/C64/Source/C64.pas
@@ -1,15 +1,28 @@
-unit C64;
+﻿unit C64;
+
+{$IFDEF FPC}
+  {$MODE Delphi}
+{$ENDIF}
 
 interface
 
 uses
-  System.Classes, WinApi.Messages, MOS6502;
+{$IFnDEF FPC}
+  WinApi.Messages, System.Classes,
+{$ELSE}
+  Messages, Classes,
+{$ENDIF}
+  MOS6502;
 
 const
   WM_SCREEN_WRITE = WM_USER + 0;
 
   CIA1 = $DC00;
-  KEY_TRANSLATION = '1�+9753'#8+#8'*piyrw'#13+#0';ljgda'#0+'2'#0'-0864'#0+' '#0'.mbcz'#0+#0'=:khfs'#0+'q'#0'@oute'#0+
+{  KEY_TRANSLATION = '1£+9753'#8+#8'*piyrw'#13+#0';ljgda'#0+'2'#0'-0864'#0+' '#0'.mbcz'#0+#0'=:khfs'#0+'q'#0'@oute'#0+
+    #0'/,nvx'#0#0+'!'#0#0')'#39'%#'+#0+#0#0#0#0#0#0#0#13+#0']'#0#0#0#0#0#0+'"'#0#0#0'(&$'#0+' '#0'>'#0#0#0#0#0+
+    #0#0'['#0#0#0#0#0+#0#0#0#0#0#0#0#0+#0'?<';
+}
+   KEY_TRANSLATION = '1'#0'+9753'#8+#8'*piyrw'#13+#0';ljgda'#0+'2'#0'-0864'#0+' '#0'.mbcz'#0+#0'=:khfs'#0+'q'#0'@oute'#0+
     #0'/,nvx'#0#0+'!'#0#0')'#39'%#'+#0+#0#0#0#0#0#0#0#13+#0']'#0#0#0#0#0#0+'"'#0#0#0'(&$'#0+' '#0'>'#0#0#0#0#0+
     #0#0'['#0#0#0#0#0+#0#0#0#0#0#0#0#0+#0'?<';
 
@@ -49,7 +62,12 @@ type
 implementation
 
 uses
-  System.SysUtils, Winapi.Windows, WinApi.MMSystem;
+{$IFnDEF FPC}
+  Winapi.Windows, System.SysUtils, WinApi.MMSystem;
+{$ELSE}
+  Windows, SysUtils, MMSystem;
+{$ENDIF}
+
 
 { TC64 }
 
@@ -111,6 +129,7 @@ begin
     Timekillevent(TimerHandle);
   Thread.Terminate;
   Thread.WaitFor;
+  Thread.Free;
   FreeMem(Memory);
   inherited;
 end;

--- a/C64/Source/C64.pas
+++ b/C64/Source/C64.pas
@@ -48,7 +48,7 @@ type
     function KeyRead: Byte;
   protected
     KeyMatrix: Array[0 .. 7, 0 .. 7] of Byte;
-    Memory: PByte;
+    Memory: array of Byte;
     InterruptRequest: Boolean;
   public
     WndHandle: THandle;
@@ -77,7 +77,7 @@ var
 begin
   C64 := TC64(dwUser);
 
-  if C64.Status and $04 = 0 then // if IRQ allowed then set irq
+  if C64.Status and INTERRUPT_FLAG = 0 then // if IRQ allowed then set irq
     C64.InterruptRequest := True;
 end;
 
@@ -118,7 +118,7 @@ begin
   inherited Create(BusRead, BusWrite);
 
   // create 64kB memory table
-  GetMem(Memory, 65536);
+  SetLength(Memory, 65536);
 
   Thread := TC64Thread.Create(Self);
 end;
@@ -130,7 +130,7 @@ begin
   Thread.Terminate;
   Thread.WaitFor;
   Thread.Free;
-  FreeMem(Memory);
+  SetLength(Memory,0);
   inherited;
 end;
 

--- a/C64/Source/C64Emu.dpr
+++ b/C64/Source/C64Emu.dpr
@@ -1,7 +1,15 @@
 program C64Emu;
 
+{$IFDEF FPC}
+  {$MODE Delphi}
+{$ENDIF}
+
 uses
+  {$IFnDEF FPC}
   Vcl.Forms,
+  {$ELSE}
+  Forms, Interfaces,
+  {$ENDIF }
   FormC64 in 'FormC64.pas' {FrmC64},
   C64 in 'C64.pas',
   MOS6502 in '..\..\Source\MOS6502.pas';

--- a/Source/MOS6502.pas
+++ b/Source/MOS6502.pas
@@ -34,17 +34,20 @@ unit MOS6502;
 interface
 
 type
+
+  { TMOS6502 }
+
   TMOS6502 = class
     const
       // Status bits
-      NEGATIVE = $80;
-      OVERFLOW = $40;
-      CONSTANT = $20;
-      BREAK_FLAG = $10;
-      DECIMAL = $08;
-      INTERRUPT = $04;
-      ZERO = $02;
-      CARRY = $01;
+      NEGATIVE_FLAG  = $80;
+      OVERFLOW_FLAG  = $40;
+      CONSTANT       = $20;
+      BREAK_CMD      = $10;
+      DECIMAL_FLAG   = $08;
+      INTERRUPT_FLAG = $04;
+      ZERO_FLAG      = $02;
+      CARRY_FLAG     = $01;
 
       // IRQ, reset, NMI vectors
       IRQVECTORH: Word = $FFFF;
@@ -61,11 +64,13 @@ type
       TInstr = record
         Addr: TAddrExec;
         Code: TCodeExec;
+        Cycles : Byte;
       end;
       PInstr = ^TInstr;
 
       TBusWrite = procedure(Adr: Word; Value: Byte) of object;
       TBusRead = function(Adr: Word): Byte of object;
+      TClockCycle = procedure(Sender : TObject) of object;
 
     procedure SET_NEGATIVE(const Value: Boolean); inline;
     procedure SET_OVERFLOW(const Value: Boolean); inline;
@@ -85,13 +90,15 @@ type
     function IF_CARRY: Byte; inline;
 
   private
+    procedure Exec(Instr : TInstr);
+
     // addressing modes
     function Addr_ACC: Word; // ACCUMULATOR
     function Addr_IMM: Word; // IMMEDIATE
     function Addr_ABS: Word; // ABSOLUTE
-    function Addr_ZER: Word; // ZERO PAGE
-    function Addr_ZEX: Word; // INDEXED-X ZERO PAGE
-    function Addr_ZEY: Word; // INDEXED-Y ZERO PAGE
+    function Addr_ZER: Word; // ZERO_FLAG PAGE
+    function Addr_ZEX: Word; // INDEXED-X ZERO_FLAG PAGE
+    function Addr_ZEY: Word; // INDEXED-Y ZERO_FLAG PAGE
     function Addr_ABX: Word; // INDEXED-X ABSOLUTE
     function Addr_ABY: Word; // INDEXED-Y ABSOLUTE
     function Addr_IMP: Word; // IMPLIED
@@ -180,48 +187,93 @@ type
 
   protected
     // consumed clock cycles
-    Cycles: Cardinal;
+    FCycles: Cardinal;
 
     InstrTable: Array [0 .. 255] of TInstr;
 
-    // read/write callbacks
-    Read: TBusRead;
-    Write: TBusWrite;
+    // read/write/ClockCycle callbacks
+    FBusReadEvent: TBusRead;
+    FBusWriteEvent: TBusWrite;
+    FClockCycleEvent: TClockCycle;
+
+    // register reset values
+    FResetA : Byte;
+    FResetX : Byte;
+    FResetY : Byte;
+    FResetSP : Byte;
+    FResetStatus : Byte;
 
     // program counter
-    Pc: Word;
+    FPC: Word;
 
     // registers
-    A: Byte; // accumulator
-    X: Byte; // X-index
-    Y: Byte; // Y-index
+    FA: Byte; // accumulator
+    FX: Byte; // X-index
+    FY: Byte; // Y-index
 
     // stack pointer
-    Sp: Byte;
+    FSP: Byte;
 
     // status register
-    Status: Byte;
+    FStatus: Byte;
 
-    IllegalOpcode: Boolean;
+    FIllegalOpcode: Boolean;
   public
-    constructor Create(R: TBusRead; W: TBusWrite); overload; virtual;
+    type
+      TCycleMethod = (INST_COUNT,CYCLE_COUNT);
+
+    constructor Create(R: TBusRead; W: TBusWrite; C: TClockCycle = Nil); overload; virtual;
+
     procedure NMI; virtual;
     procedure IRQ; virtual;
     procedure Reset; virtual;
-    procedure Step; virtual;
+    procedure Step; virtual;deprecated 'Please use Run or RunEternally';
+    procedure Run(Cycles : Cardinal;
+                  var CycleCount : UInt64;
+                  CycleMethod : TCycleMethod = CYCLE_COUNT);
+    procedure RunEternally; // until it encounters FA illegal opcode
+    			// useful when running e.g. WOZ Monitor
+    			// no need to worry about cycle exhaustion
+    {
+    property BusReadEvent: TBusRead read FBusReadEvent write FBusReadEvent;
+    property BusWriteEvent: TBusWrite read FBusWriteEvent write FBusWriteEvent;
+    property ClockCycleEvent: TClockCycle read FClockCycleEvent write FClockCycleEvent;
+    }
+
+    property PC : Word read FPC; // ProgramCounter
+    property SP : Byte read FSP; // StacPointer
+    property Status : Byte read FStatus; //ProcessorStatusRegister "P" in mos6502.h/.c
+    property A : Byte read FA;
+    property X : Byte read FX;
+    property Y : Byte read FY;
+    property ResetA : Byte read FResetA write FResetA;
+    property ResetX : Byte read FResetX write FResetX;
+    property ResetY : Byte read FResetY write FResetY;
+    property ResetSP : Byte read FResetSP write FResetSP;
+    property ResetStatus : Byte read FResetStatus write FResetStatus;
+    property IllegalOpcode: Boolean read FIllegalOpcode write FIllegalOpcode;
+
   end;
 
 implementation
 
 { TMOS6502 }
 
-constructor TMOS6502.Create(R: TBusRead; W: TBusWrite);
+constructor TMOS6502.Create(R: TBusRead; W: TBusWrite; C: TClockCycle = Nil);
 var
   Instr: TInstr;
   I: Integer;
 begin
-  Write := W;
-  Read := R;
+  inherited Create;
+  FResetA := $00;
+  FResetX := $00;
+  FResetY := $00;
+  FResetSP := $FD;
+  FResetStatus := CONSTANT;
+
+  FBusWriteEvent := W;
+  FBusReadEvent := R;
+  FClockCycleEvent := C;
 
   // fill jump table with ILLEGALs
   Instr.Addr := Addr_IMP;
@@ -232,620 +284,779 @@ begin
   // insert opcodes
   Instr.Addr := Addr_IMM;
   Instr.Code := Op_ADC;
+  Instr.Cycles := 2;
   InstrTable[$69] := Instr;
   Instr.Addr := Addr_ABS;
   Instr.Code := Op_ADC;
+  Instr.Cycles := 4;
   InstrTable[$6D] := Instr;
   Instr.Addr := Addr_ZER;
   Instr.Code := Op_ADC;
+  Instr.Cycles := 3;
   InstrTable[$65] := Instr;
   Instr.Addr := Addr_INX;
   Instr.Code := Op_ADC;
+  Instr.Cycles := 6;
   InstrTable[$61] := Instr;
   Instr.Addr := Addr_INY;
   Instr.Code := Op_ADC;
+  Instr.Cycles := 6;
   InstrTable[$71] := Instr;
   Instr.Addr := Addr_ZEX;
   Instr.Code := Op_ADC;
+  Instr.Cycles := 4;
   InstrTable[$75] := Instr;
   Instr.Addr := Addr_ABX;
   Instr.Code := Op_ADC;
+  Instr.Cycles := 4;
   InstrTable[$7D] := Instr;
   Instr.Addr := Addr_ABY;
   Instr.Code := Op_ADC;
+  Instr.Cycles := 4;
   InstrTable[$79] := Instr;
 
   Instr.Addr := Addr_IMM;
   Instr.Code := Op_AND;
+  Instr.Cycles := 2;
   InstrTable[$29] := Instr;
   Instr.Addr := Addr_ABS;
   Instr.Code := Op_AND;
+  Instr.Cycles := 4;
   InstrTable[$2D] := Instr;
   Instr.Addr := Addr_ZER;
   Instr.Code := Op_AND;
+  Instr.Cycles := 3;
   InstrTable[$25] := Instr;
   Instr.Addr := Addr_INX;
   Instr.Code := Op_AND;
+  Instr.Cycles := 6;
   InstrTable[$21] := Instr;
   Instr.Addr := Addr_INY;
   Instr.Code := Op_AND;
+  Instr.Cycles := 5;
   InstrTable[$31] := Instr;
   Instr.Addr := Addr_ZEX;
   Instr.Code := Op_AND;
+  Instr.Cycles := 4;
   InstrTable[$35] := Instr;
   Instr.Addr := Addr_ABX;
   Instr.Code := Op_AND;
+  Instr.Cycles := 4;
   InstrTable[$3D] := Instr;
   Instr.Addr := Addr_ABY;
   Instr.Code := Op_AND;
+  Instr.Cycles := 4;
   InstrTable[$39] := Instr;
 
   Instr.Addr := Addr_ABS;
   Instr.Code := Op_ASL;
+  Instr.Cycles := 6;
   InstrTable[$0E] := Instr;
   Instr.Addr := Addr_ZER;
   Instr.Code := Op_ASL;
+  Instr.Cycles := 5;
   InstrTable[$06] := Instr;
   Instr.Addr := Addr_ACC;
   Instr.Code := Op_ASL_ACC;
+  Instr.Cycles := 2;
   InstrTable[$0A] := Instr;
   Instr.Addr := Addr_ZEX;
   Instr.Code := Op_ASL;
+  Instr.Cycles := 6;
   InstrTable[$16] := Instr;
   Instr.Addr := Addr_ABX;
   Instr.Code := Op_ASL;
+  Instr.Cycles := 7;
   InstrTable[$1E] := Instr;
 
   Instr.Addr := Addr_REL;
   Instr.Code := Op_BCC;
+  Instr.Cycles := 2;
   InstrTable[$90] := Instr;
 
   Instr.Addr := Addr_REL;
   Instr.Code := Op_BCS;
+  Instr.Cycles := 2;
   InstrTable[$B0] := Instr;
 
   Instr.Addr := Addr_REL;
   Instr.Code := Op_BEQ;
+  Instr.Cycles := 2;
   InstrTable[$F0] := Instr;
 
   Instr.Addr := Addr_ABS;
   Instr.Code := Op_BIT;
+  Instr.Cycles := 4;
   InstrTable[$2C] := Instr;
   Instr.Addr := Addr_ZER;
   Instr.Code := Op_BIT;
+  Instr.Cycles := 3;
   InstrTable[$24] := Instr;
 
   Instr.Addr := Addr_REL;
   Instr.Code := Op_BMI;
+  Instr.Cycles := 2;
   InstrTable[$30] := Instr;
 
   Instr.Addr := Addr_REL;
   Instr.Code := Op_BNE;
+  Instr.Cycles := 2;
   InstrTable[$D0] := Instr;
 
   Instr.Addr := Addr_REL;
   Instr.Code := Op_BPL;
+  Instr.Cycles := 2;
   InstrTable[$10] := Instr;
 
   Instr.Addr := Addr_IMP;
   Instr.Code := Op_BRK;
+  Instr.Cycles := 7;
   InstrTable[$00] := Instr;
 
   Instr.Addr := Addr_REL;
   Instr.Code := Op_BVC;
+  Instr.Cycles := 2;
   InstrTable[$50] := Instr;
 
   Instr.Addr := Addr_REL;
   Instr.Code := Op_BVS;
+  Instr.Cycles := 2;
   InstrTable[$70] := Instr;
 
   Instr.Addr := Addr_IMP;
   Instr.Code := Op_CLC;
+  Instr.Cycles := 2;
   InstrTable[$18] := Instr;
 
   Instr.Addr := Addr_IMP;
   Instr.Code := Op_CLD;
+  Instr.Cycles := 2;
   InstrTable[$D8] := Instr;
 
   Instr.Addr := Addr_IMP;
   Instr.Code := Op_CLI;
+  Instr.Cycles := 2;
   InstrTable[$58] := Instr;
 
   Instr.Addr := Addr_IMP;
   Instr.Code := Op_CLV;
+  Instr.Cycles := 2;
   InstrTable[$B8] := Instr;
 
   Instr.Addr := Addr_IMM;
   Instr.Code := Op_CMP;
+  Instr.Cycles := 2;
   InstrTable[$C9] := Instr;
   Instr.Addr := Addr_ABS;
   Instr.Code := Op_CMP;
+  Instr.Cycles := 4;
   InstrTable[$CD] := Instr;
   Instr.Addr := Addr_ZER;
   Instr.Code := Op_CMP;
+  Instr.Cycles := 3;
   InstrTable[$C5] := Instr;
   Instr.Addr := Addr_INX;
   Instr.Code := Op_CMP;
+  Instr.Cycles := 6;
   InstrTable[$C1] := Instr;
   Instr.Addr := Addr_INY;
   Instr.Code := Op_CMP;
+  Instr.Cycles := 3;
   InstrTable[$D1] := Instr;
   Instr.Addr := Addr_ZEX;
   Instr.Code := Op_CMP;
+  Instr.Cycles := 4;
   InstrTable[$D5] := Instr;
   Instr.Addr := Addr_ABX;
   Instr.Code := Op_CMP;
+  Instr.Cycles := 4;
   InstrTable[$DD] := Instr;
   Instr.Addr := Addr_ABY;
   Instr.Code := Op_CMP;
+  Instr.Cycles := 4;
   InstrTable[$D9] := Instr;
 
   Instr.Addr := Addr_IMM;
   Instr.Code := Op_CPX;
+  Instr.Cycles := 2;
   InstrTable[$E0] := Instr;
   Instr.Addr := Addr_ABS;
   Instr.Code := Op_CPX;
+  Instr.Cycles := 4;
   InstrTable[$EC] := Instr;
   Instr.Addr := Addr_ZER;
   Instr.Code := Op_CPX;
+  Instr.Cycles := 3;
   InstrTable[$E4] := Instr;
 
   Instr.Addr := Addr_IMM;
   Instr.Code := Op_CPY;
+  Instr.Cycles := 2;
   InstrTable[$C0] := Instr;
   Instr.Addr := Addr_ABS;
   Instr.Code := Op_CPY;
+  Instr.Cycles := 4;
   InstrTable[$CC] := Instr;
   Instr.Addr := Addr_ZER;
   Instr.Code := Op_CPY;
+  Instr.Cycles := 3;
   InstrTable[$C4] := Instr;
 
   Instr.Addr := Addr_ABS;
   Instr.Code := Op_DEC;
+  Instr.Cycles := 6;
   InstrTable[$CE] := Instr;
   Instr.Addr := Addr_ZER;
   Instr.Code := Op_DEC;
+  Instr.Cycles := 5;
   InstrTable[$C6] := Instr;
   Instr.Addr := Addr_ZEX;
   Instr.Code := Op_DEC;
+  Instr.Cycles := 6;
   InstrTable[$D6] := Instr;
   Instr.Addr := Addr_ABX;
   Instr.Code := Op_DEC;
+  Instr.Cycles := 7;
   InstrTable[$DE] := Instr;
 
   Instr.Addr := Addr_IMP;
   Instr.Code := Op_DEX;
+  Instr.Cycles := 2;
   InstrTable[$CA] := Instr;
 
   Instr.Addr := Addr_IMP;
   Instr.Code := Op_DEY;
+  Instr.Cycles := 2;
   InstrTable[$88] := Instr;
 
   Instr.Addr := Addr_IMM;
   Instr.Code := Op_EOR;
+  Instr.Cycles := 2;
   InstrTable[$49] := Instr;
   Instr.Addr := Addr_ABS;
   Instr.Code := Op_EOR;
+  Instr.Cycles := 4;
   InstrTable[$4D] := Instr;
   Instr.Addr := Addr_ZER;
   Instr.Code := Op_EOR;
+  Instr.Cycles := 3;
   InstrTable[$45] := Instr;
   Instr.Addr := Addr_INX;
   Instr.Code := Op_EOR;
+  Instr.Cycles := 6;
   InstrTable[$41] := Instr;
   Instr.Addr := Addr_INY;
   Instr.Code := Op_EOR;
+  Instr.Cycles := 5;
   InstrTable[$51] := Instr;
   Instr.Addr := Addr_ZEX;
   Instr.Code := Op_EOR;
+  Instr.Cycles := 4;
   InstrTable[$55] := Instr;
   Instr.Addr := Addr_ABX;
   Instr.Code := Op_EOR;
+  Instr.Cycles := 4;
   InstrTable[$5D] := Instr;
   Instr.Addr := Addr_ABY;
   Instr.Code := Op_EOR;
+  Instr.Cycles := 4;
   InstrTable[$59] := Instr;
 
   Instr.Addr := Addr_ABS;
   Instr.Code := Op_INC;
+  Instr.Cycles := 6;
   InstrTable[$EE] := Instr;
   Instr.Addr := Addr_ZER;
   Instr.Code := Op_INC;
+  Instr.Cycles := 5;
   InstrTable[$E6] := Instr;
   Instr.Addr := Addr_ZEX;
   Instr.Code := Op_INC;
+  Instr.Cycles := 6;
   InstrTable[$F6] := Instr;
   Instr.Addr := Addr_ABX;
   Instr.Code := Op_INC;
+  Instr.Cycles := 7;
   InstrTable[$FE] := Instr;
 
   Instr.Addr := Addr_IMP;
   Instr.Code := Op_INX;
+  Instr.Cycles := 2;
   InstrTable[$E8] := Instr;
 
   Instr.Addr := Addr_IMP;
   Instr.Code := Op_INY;
+  Instr.Cycles := 2;
   InstrTable[$C8] := Instr;
 
   Instr.Addr := Addr_ABS;
   Instr.Code := Op_JMP;
+  Instr.Cycles := 3;
   InstrTable[$4C] := Instr;
   Instr.Addr := Addr_ABI;
   Instr.Code := Op_JMP;
+  Instr.Cycles := 5;
   InstrTable[$6C] := Instr;
 
   Instr.Addr := Addr_ABS;
   Instr.Code := Op_JSR;
+  Instr.Cycles := 6;
   InstrTable[$20] := Instr;
 
   Instr.Addr := Addr_IMM;
   Instr.Code := Op_LDA;
+  Instr.Cycles := 2;
   InstrTable[$A9] := Instr;
   Instr.Addr := Addr_ABS;
   Instr.Code := Op_LDA;
+  Instr.Cycles := 4;
   InstrTable[$AD] := Instr;
   Instr.Addr := Addr_ZER;
   Instr.Code := Op_LDA;
+  Instr.Cycles := 3;
   InstrTable[$A5] := Instr;
   Instr.Addr := Addr_INX;
   Instr.Code := Op_LDA;
+  Instr.Cycles := 6;
   InstrTable[$A1] := Instr;
   Instr.Addr := Addr_INY;
   Instr.Code := Op_LDA;
+  Instr.Cycles := 5;
   InstrTable[$B1] := Instr;
   Instr.Addr := Addr_ZEX;
   Instr.Code := Op_LDA;
+  Instr.Cycles := 4;
   InstrTable[$B5] := Instr;
   Instr.Addr := Addr_ABX;
   Instr.Code := Op_LDA;
+  Instr.Cycles := 4;
   InstrTable[$BD] := Instr;
   Instr.Addr := Addr_ABY;
   Instr.Code := Op_LDA;
+  Instr.Cycles := 4;
   InstrTable[$B9] := Instr;
 
   Instr.Addr := Addr_IMM;
   Instr.Code := Op_LDX;
+  Instr.Cycles := 2;
   InstrTable[$A2] := Instr;
   Instr.Addr := Addr_ABS;
   Instr.Code := Op_LDX;
+  Instr.Cycles := 4;
   InstrTable[$AE] := Instr;
   Instr.Addr := Addr_ZER;
   Instr.Code := Op_LDX;
+  Instr.Cycles := 3;
   InstrTable[$A6] := Instr;
   Instr.Addr := Addr_ABY;
   Instr.Code := Op_LDX;
+  Instr.Cycles := 4;
   InstrTable[$BE] := Instr;
   Instr.Addr := Addr_ZEY;
   Instr.Code := Op_LDX;
+  Instr.Cycles := 4;
   InstrTable[$B6] := Instr;
 
   Instr.Addr := Addr_IMM;
   Instr.Code := Op_LDY;
+  Instr.Cycles := 2;
   InstrTable[$A0] := Instr;
   Instr.Addr := Addr_ABS;
   Instr.Code := Op_LDY;
+  Instr.Cycles := 4;
   InstrTable[$AC] := Instr;
   Instr.Addr := Addr_ZER;
   Instr.Code := Op_LDY;
+  Instr.Cycles := 3;
   InstrTable[$A4] := Instr;
   Instr.Addr := Addr_ZEX;
   Instr.Code := Op_LDY;
+  Instr.Cycles := 4;
   InstrTable[$B4] := Instr;
   Instr.Addr := Addr_ABX;
   Instr.Code := Op_LDY;
+  Instr.Cycles := 4;
   InstrTable[$BC] := Instr;
 
   Instr.Addr := Addr_ABS;
   Instr.Code := Op_LSR;
+  Instr.Cycles := 6;
   InstrTable[$4E] := Instr;
   Instr.Addr := Addr_ZER;
   Instr.Code := Op_LSR;
+  Instr.Cycles := 5;
   InstrTable[$46] := Instr;
   Instr.Addr := Addr_ACC;
   Instr.Code := Op_LSR_ACC;
+  Instr.Cycles := 2;
   InstrTable[$4A] := Instr;
   Instr.Addr := Addr_ZEX;
   Instr.Code := Op_LSR;
+  Instr.Cycles := 6;
   InstrTable[$56] := Instr;
   Instr.Addr := Addr_ABX;
   Instr.Code := Op_LSR;
+  Instr.Cycles := 7;
   InstrTable[$5E] := Instr;
 
   Instr.Addr := Addr_IMP;
   Instr.Code := Op_NOP;
+  Instr.Cycles := 2;
   InstrTable[$EA] := Instr;
 
   Instr.Addr := Addr_IMM;
   Instr.Code := Op_ORA;
+  Instr.Cycles := 2;
   InstrTable[$09] := Instr;
   Instr.Addr := Addr_ABS;
   Instr.Code := Op_ORA;
+  Instr.Cycles := 4;
   InstrTable[$0D] := Instr;
   Instr.Addr := Addr_ZER;
   Instr.Code := Op_ORA;
+  Instr.Cycles := 3;
   InstrTable[$05] := Instr;
   Instr.Addr := Addr_INX;
   Instr.Code := Op_ORA;
+  Instr.Cycles := 6;
   InstrTable[$01] := Instr;
   Instr.Addr := Addr_INY;
   Instr.Code := Op_ORA;
+  Instr.Cycles := 5;
   InstrTable[$11] := Instr;
   Instr.Addr := Addr_ZEX;
   Instr.Code := Op_ORA;
+  Instr.Cycles := 4;
   InstrTable[$15] := Instr;
   Instr.Addr := Addr_ABX;
   Instr.Code := Op_ORA;
+  Instr.Cycles := 4;
   InstrTable[$1D] := Instr;
   Instr.Addr := Addr_ABY;
   Instr.Code := Op_ORA;
+  Instr.Cycles := 4;
   InstrTable[$19] := Instr;
 
   Instr.Addr := Addr_IMP;
   Instr.Code := Op_PHA;
+  Instr.Cycles := 3;
   InstrTable[$48] := Instr;
 
   Instr.Addr := Addr_IMP;
   Instr.Code := Op_PHP;
+  Instr.Cycles := 3;
   InstrTable[$08] := Instr;
 
   Instr.Addr := Addr_IMP;
   Instr.Code := Op_PLA;
+  Instr.Cycles := 4;
   InstrTable[$68] := Instr;
 
   Instr.Addr := Addr_IMP;
   Instr.Code := Op_PLP;
+  Instr.Cycles := 4;
   InstrTable[$28] := Instr;
 
   Instr.Addr := Addr_ABS;
   Instr.Code := Op_ROL;
+  Instr.Cycles := 6;
   InstrTable[$2E] := Instr;
   Instr.Addr := Addr_ZER;
   Instr.Code := Op_ROL;
+  Instr.Cycles := 5;
   InstrTable[$26] := Instr;
   Instr.Addr := Addr_ACC;
   Instr.Code := Op_ROL_ACC;
+  Instr.Cycles := 2;
   InstrTable[$2A] := Instr;
   Instr.Addr := Addr_ZEX;
   Instr.Code := Op_ROL;
+  Instr.Cycles := 6;
   InstrTable[$36] := Instr;
   Instr.Addr := Addr_ABX;
   Instr.Code := Op_ROL;
+  Instr.Cycles := 7;
   InstrTable[$3E] := Instr;
 
   Instr.Addr := Addr_ABS;
   Instr.Code := Op_ROR;
+  Instr.Cycles := 6;
   InstrTable[$6E] := Instr;
   Instr.Addr := Addr_ZER;
   Instr.Code := Op_ROR;
+  Instr.Cycles := 5;
   InstrTable[$66] := Instr;
   Instr.Addr := Addr_ACC;
   Instr.Code := Op_ROR_ACC;
+  Instr.Cycles := 2;
   InstrTable[$6A] := Instr;
   Instr.Addr := Addr_ZEX;
   Instr.Code := Op_ROR;
+  Instr.Cycles := 6;
   InstrTable[$76] := Instr;
   Instr.Addr := Addr_ABX;
   Instr.Code := Op_ROR;
+  Instr.Cycles := 7;
   InstrTable[$7E] := Instr;
 
   Instr.Addr := Addr_IMP;
   Instr.Code := Op_RTI;
+  Instr.Cycles := 6;
   InstrTable[$40] := Instr;
 
   Instr.Addr := Addr_IMP;
   Instr.Code := Op_RTS;
+  Instr.Cycles := 6;
   InstrTable[$60] := Instr;
 
   Instr.Addr := Addr_IMM;
   Instr.Code := Op_SBC;
+  Instr.Cycles := 2;
   InstrTable[$E9] := Instr;
   Instr.Addr := Addr_ABS;
   Instr.Code := Op_SBC;
+  Instr.Cycles := 4;
   InstrTable[$ED] := Instr;
   Instr.Addr := Addr_ZER;
   Instr.Code := Op_SBC;
+  Instr.Cycles := 3;
   InstrTable[$E5] := Instr;
   Instr.Addr := Addr_INX;
   Instr.Code := Op_SBC;
+  Instr.Cycles := 6;
   InstrTable[$E1] := Instr;
   Instr.Addr := Addr_INY;
   Instr.Code := Op_SBC;
+  Instr.Cycles := 5;
   InstrTable[$F1] := Instr;
   Instr.Addr := Addr_ZEX;
   Instr.Code := Op_SBC;
+  Instr.Cycles := 4;
   InstrTable[$F5] := Instr;
   Instr.Addr := Addr_ABX;
   Instr.Code := Op_SBC;
+  Instr.Cycles := 4;
   InstrTable[$FD] := Instr;
   Instr.Addr := Addr_ABY;
   Instr.Code := Op_SBC;
+  Instr.Cycles := 4;
   InstrTable[$F9] := Instr;
 
   Instr.Addr := Addr_IMP;
   Instr.Code := Op_SEC;
+  Instr.Cycles := 2;
   InstrTable[$38] := Instr;
 
   Instr.Addr := Addr_IMP;
   Instr.Code := Op_SED;
+  Instr.Cycles := 2;
   InstrTable[$F8] := Instr;
 
   Instr.Addr := Addr_IMP;
   Instr.Code := Op_SEI;
+  Instr.Cycles := 2;
   InstrTable[$78] := Instr;
 
   Instr.Addr := Addr_ABS;
   Instr.Code := Op_STA;
+  Instr.Cycles := 4;
   InstrTable[$8D] := Instr;
   Instr.Addr := Addr_ZER;
   Instr.Code := Op_STA;
+  Instr.Cycles := 3;
   InstrTable[$85] := Instr;
   Instr.Addr := Addr_INX;
   Instr.Code := Op_STA;
+  Instr.Cycles := 6;
   InstrTable[$81] := Instr;
   Instr.Addr := Addr_INY;
   Instr.Code := Op_STA;
+  Instr.Cycles := 6;
   InstrTable[$91] := Instr;
   Instr.Addr := Addr_ZEX;
   Instr.Code := Op_STA;
+  Instr.Cycles := 4;
   InstrTable[$95] := Instr;
   Instr.Addr := Addr_ABX;
   Instr.Code := Op_STA;
+  Instr.Cycles := 5;
   InstrTable[$9D] := Instr;
   Instr.Addr := Addr_ABY;
   Instr.Code := Op_STA;
+  Instr.Cycles := 5;
   InstrTable[$99] := Instr;
 
   Instr.Addr := Addr_ABS;
   Instr.Code := Op_STX;
+  Instr.Cycles := 4;
   InstrTable[$8E] := Instr;
   Instr.Addr := Addr_ZER;
   Instr.Code := Op_STX;
+  Instr.Cycles := 3;
   InstrTable[$86] := Instr;
   Instr.Addr := Addr_ZEY;
   Instr.Code := Op_STX;
+  Instr.Cycles := 4;
   InstrTable[$96] := Instr;
 
   Instr.Addr := Addr_ABS;
   Instr.Code := Op_STY;
+  Instr.Cycles := 4;
   InstrTable[$8C] := Instr;
   Instr.Addr := Addr_ZER;
   Instr.Code := Op_STY;
+  Instr.Cycles := 3;
   InstrTable[$84] := Instr;
   Instr.Addr := Addr_ZEX;
   Instr.Code := Op_STY;
+  Instr.Cycles := 4;
   InstrTable[$94] := Instr;
 
   Instr.Addr := Addr_IMP;
   Instr.Code := Op_TAX;
+  Instr.Cycles := 2;
   InstrTable[$AA] := Instr;
 
   Instr.Addr := Addr_IMP;
   Instr.Code := Op_TAY;
+  Instr.Cycles := 2;
   InstrTable[$A8] := Instr;
 
   Instr.Addr := Addr_IMP;
   Instr.Code := Op_TSX;
+  Instr.Cycles := 2;
   InstrTable[$BA] := Instr;
 
   Instr.Addr := Addr_IMP;
   Instr.Code := Op_TXA;
+  Instr.Cycles := 2;
   InstrTable[$8A] := Instr;
 
   Instr.Addr := Addr_IMP;
   Instr.Code := Op_TXS;
+  Instr.Cycles := 2;
   InstrTable[$9A] := Instr;
 
   Instr.Addr := Addr_IMP;
   Instr.Code := Op_TYA;
+  Instr.Cycles := 2;
   InstrTable[$98] := Instr;
 end;
 
 procedure TMOS6502.SET_NEGATIVE(const Value: Boolean);
 begin
   if Value then
-    Status := Status or NEGATIVE
+    FStatus := FStatus or NEGATIVE_FLAG
   else
-    Status := Status and (not NEGATIVE);
+    FStatus := FStatus and (not NEGATIVE_FLAG);
 end;
 
 procedure TMOS6502.SET_OVERFLOW(const Value: Boolean);
 begin
   if Value then
-    Status := Status or OVERFLOW
+    FStatus := FStatus or OVERFLOW_FLAG
   else
-    Status := Status and (not OVERFLOW);
+    FStatus := FStatus and (not OVERFLOW_FLAG);
 end;
 
 procedure TMOS6502.SET_CONSTANT(const Value: Boolean);
 begin
   if Value then
-    Status := Status or CONSTANT
+    FStatus := FStatus or CONSTANT
   else
-    Status := Status and (not CONSTANT);
+    FStatus := FStatus and (not CONSTANT);
 end;
 
 procedure TMOS6502.SET_BREAK(const Value: Boolean);
 begin
   if Value then
-    Status := Status or BREAK_FLAG
+    FStatus := FStatus or BREAK_CMD
   else
-    Status := Status and (not BREAK_FLAG);
+    FStatus := FStatus and (not BREAK_CMD);
 end;
 
 procedure TMOS6502.SET_DECIMAL(const Value: Boolean);
 begin
   if Value then
-    Status := Status or DECIMAL
+    FStatus := FStatus or DECIMAL_FLAG
   else
-    Status := Status and (not DECIMAL);
+    FStatus := FStatus and (not DECIMAL_FLAG);
 end;
 
 procedure TMOS6502.SET_INTERRUPT(const Value: Boolean);
 begin
   if Value then
-    Status := Status or INTERRUPT
+    FStatus := FStatus or INTERRUPT_FLAG
   else
-    Status := Status and (not INTERRUPT);
+    FStatus := FStatus and (not INTERRUPT_FLAG);
 end;
 
 procedure TMOS6502.SET_ZERO(const Value: Boolean);
 begin
   if Value then
-    Status := Status or ZERO
+    FStatus := FStatus or ZERO_FLAG
   else
-    Status := Status and (not ZERO);
+    FStatus := FStatus and (not ZERO_FLAG);
 end;
 
 procedure TMOS6502.SET_CARRY(const Value: Boolean);
 begin
   if Value then
-    Status := Status or CARRY
+    FStatus := FStatus or CARRY_FLAG
   else
-    Status := Status and (not CARRY);
+    FStatus := FStatus and (not CARRY_FLAG);
 end;
 
 
 function TMOS6502.IF_NEGATIVE: Boolean;
 begin
-  Result := ((Status and NEGATIVE) <> 0);
+  Result := ((FStatus and NEGATIVE_FLAG) <> 0);
 end;
 
 function TMOS6502.IF_OVERFLOW: Boolean;
 begin
-  Result := ((Status and OVERFLOW) <> 0);
+  Result := ((FStatus and OVERFLOW_FLAG) <> 0);
 end;
 
 function TMOS6502.IF_CONSTANT: Boolean;
 begin
-  Result := ((Status and CONSTANT) <> 0);
+  Result := ((FStatus and CONSTANT) <> 0);
 end;
 
 function TMOS6502.IF_BREAK: Boolean;
 begin
-  Result := ((Status and BREAK_FLAG) <> 0);
+  Result := ((FStatus and BREAK_CMD) <> 0);
 end;
 
 function TMOS6502.IF_DECIMAL: Boolean;
 begin
-  Result := ((Status and DECIMAL) <> 0);
+  Result := ((FStatus and DECIMAL_FLAG) <> 0);
 end;
 
 function TMOS6502.IF_INTERRUPT: Boolean;
 begin
-  Result := ((Status and INTERRUPT) <> 0);
+  Result := ((FStatus and INTERRUPT_FLAG) <> 0);
 end;
 
 function TMOS6502.IF_ZERO: Boolean;
 begin
-  Result := ((Status and ZERO) <> 0);
+  Result := ((FStatus and ZERO_FLAG) <> 0);
 end;
 
 function TMOS6502.IF_CARRY: Byte;
 begin
-  if (Status and CARRY) <> 0 then
+  if (FStatus and CARRY_FLAG) <> 0 then
     Result := 1
   else
     Result := 0;
+end;
+
+procedure TMOS6502.Exec(Instr: TInstr);
+var
+  Src: Word;
+begin
+  Src := Instr.Addr;
+  Instr.Code(Src);
 end;
 
 function TMOS6502.Addr_ACC: Word;
@@ -855,18 +1066,18 @@ end;
 
 function TMOS6502.Addr_IMM: Word;
 begin
-  Result := Pc;
-  Inc(Pc);
+  Result := FPC;
+  Inc(FPC);
 end;
 
 function TMOS6502.Addr_ABS: Word;
 var
   AddrL, AddrH, Addr: Word;
 begin
-  AddrL := Read(Pc);
-  Inc(Pc);
-  AddrH := Read(Pc);
-  Inc(Pc);
+  AddrL := FBusReadEvent(FPC);
+  Inc(FPC);
+  AddrH := FBusReadEvent(FPC);
+  Inc(FPC);
 
   Addr := AddrL + (AddrH shl 8);
 
@@ -875,8 +1086,8 @@ end;
 
 function TMOS6502.Addr_ZER: Word;
 begin
-  Result := Read(Pc);
-  Inc(Pc);
+  Result := FBusReadEvent(FPC);
+  Inc(FPC);
 end;
 
 function TMOS6502.Addr_IMP: Word;
@@ -888,12 +1099,12 @@ function TMOS6502.Addr_REL: Word;
 var
   Offset, Addr: Word;
 begin
-  Offset := Read(Pc);
-  Inc(Pc);
+  Offset := FBusReadEvent(FPC);
+  Inc(FPC);
   if (Offset and $80) <> 0 then
     Offset := Offset or $FF00;
 
-  {$R-}Addr := Pc + Offset;{$R+}
+  {$R-}Addr := FPC + Offset;{$R+}
   Result := Addr;
 end;
 
@@ -901,14 +1112,14 @@ function TMOS6502.Addr_ABI: Word;
 var
   AddrL, AddrH, EffL, EffH, Abs, Addr: Word;
 begin
-  AddrL := Read(Pc);
-  Inc(Pc);
-  AddrH := Read(Pc);
-  Inc(Pc);
+  AddrL := FBusReadEvent(FPC);
+  Inc(FPC);
+  AddrH := FBusReadEvent(FPC);
+  Inc(FPC);
 
   Abs := (AddrH shl 8) or AddrL;
-  EffL := Read(Abs);
-  EffH := Read((Abs and $FF00) + ((Abs + 1) and $00FF));
+  EffL := FBusReadEvent(Abs);
+  EffH := FBusReadEvent((Abs and $FF00) + ((Abs + 1) and $00FF));
 
   Addr := EffL + $100 * EffH;
   Result := Addr;
@@ -918,8 +1129,8 @@ function TMOS6502.Addr_ZEX: Word;
 var
   Addr: Word;
 begin
-  Addr := (Read(Pc) + X) mod 256;
-  Inc(Pc);
+  Addr := (FBusReadEvent(FPC) + FX) mod 256;
+  Inc(FPC);
   Result := Addr;
 end;
 
@@ -927,8 +1138,8 @@ function TMOS6502.Addr_ZEY: Word;
 var
   Addr: Word;
 begin
-  Addr := (Read(Pc) + Y) mod 256;
-  Inc(Pc);
+  Addr := (FBusReadEvent(FPC) + FY) mod 256;
+  Inc(FPC);
   Result := Addr;
 end;
 
@@ -938,12 +1149,12 @@ var
   AddrH: Word;
   Addr: Word;
 begin
-  AddrL := Read(Pc);
-  Inc(Pc);
-  AddrH := Read(Pc);
-  Inc(Pc);
+  AddrL := FBusReadEvent(FPC);
+  Inc(FPC);
+  AddrH := FBusReadEvent(FPC);
+  Inc(FPC);
 
-  Addr := AddrL + (AddrH shl 8) + X;
+  Addr := AddrL + (AddrH shl 8) + FX;
   Result := Addr;
 end;
 
@@ -953,12 +1164,12 @@ var
   AddrH: Word;
   Addr: Word;
 begin
-  AddrL := Read(Pc);
-  Inc(Pc);
-  AddrH := Read(Pc);
-  Inc(Pc);
+  AddrL := FBusReadEvent(FPC);
+  Inc(FPC);
+  AddrH := FBusReadEvent(FPC);
+  Inc(FPC);
 
-  Addr := AddrL + (AddrH shl 8) + Y;
+  Addr := AddrL + (AddrH shl 8) + FY;
   Result := Addr;
 end;
 
@@ -967,10 +1178,10 @@ var
   ZeroL, ZeroH: Word;
   Addr: Word;
 begin
-  ZeroL := (Read(Pc) + X) mod 256;
-  Inc(Pc);
+  ZeroL := (FBusReadEvent(FPC) + FX) mod 256;
+  Inc(FPC);
   ZeroH := (ZeroL + 1) mod 256;
-  Addr := Read(ZeroL) + (Read(ZeroH) shl 8);
+  Addr := FBusReadEvent(ZeroL) + (FBusReadEvent(ZeroH) shl 8);
   Result := Addr;
 end;
 
@@ -979,46 +1190,46 @@ var
   ZeroL, ZeroH: Word;
   Addr: Word;
 begin
-  ZeroL := Read(Pc);
-  Inc(Pc);
+  ZeroL := FBusReadEvent(FPC);
+  Inc(FPC);
 
   ZeroH := (ZeroL + 1) mod 256;
-  Addr := Read(ZeroL) + (Read(ZeroH) shl 8) + Y;
+  Addr := FBusReadEvent(ZeroL) + (FBusReadEvent(ZeroH) shl 8) + FY;
   Result := Addr;
 end;
 
 procedure TMOS6502.Reset;
 begin
-  A := $aa;
-  X := $00;
-  Y := $00;
+  FA := $aa;
+  FX := $00;
+  FY := $00;
 
-  Status := BREAK_FLAG or INTERRUPT OR ZERO or CONSTANT;
-  Sp := $FD;
+  FStatus := BREAK_CMD or INTERRUPT_FLAG OR ZERO_FLAG or CONSTANT;
+  FSP := $FD;
 
-  Pc := (Read(RSTVECTORH) shl 8) + Read(RSTVECTORL); // load PC from reset vector
+  FPC := (FBusReadEvent(RSTVECTORH) shl 8) + FBusReadEvent(RSTVECTORL); // load FPC from reset vector
 
-  Cycles := 6; // according to the datasheet, the reset routine takes 6 clock cycles
-  IllegalOpcode := false;
+  FCycles := 6; // according to the datasheet, the reset routine takes 6 clock FCycles
+  FIllegalOpcode := false;
 end;
 
 procedure TMOS6502.StackPush(const Value: Byte);
 begin
-  Write($0100 + Sp, Value);
-  if Sp = $00 then
-    Sp := $FF
+  FBusWriteEvent($0100 + FSP, Value);
+  if FSP = $00 then
+    FSP := $FF
   else
-    Dec(Sp);
+    Dec(FSP);
 end;
 
 function TMOS6502.StackPop: Byte;
 begin
-  if Sp = $FF then
-    Sp := $00
+  if FSP = $FF then
+    FSP := $00
   else
-    Inc(Sp);
+    Inc(FSP);
 
-  Result := Read($0100 + Sp);
+  Result := FBusReadEvent($0100 + FSP);
 end;
 
 procedure TMOS6502.IRQ;
@@ -1026,45 +1237,117 @@ begin
   if (not IF_INTERRUPT) then
   begin
     SET_BREAK(False);
-    StackPush((Pc shr 8) and $FF);
-    StackPush(Pc and $FF);
-    StackPush(Status);
+    StackPush((FPC shr 8) and $FF);
+    StackPush(FPC and $FF);
+    StackPush(FStatus);
     SET_INTERRUPT(True);
-    Pc := (Read(IRQVECTORH) shl 8) + Read(IRQVECTORL);
+    FPC := (FBusReadEvent(IRQVECTORH) shl 8) + FBusReadEvent(IRQVECTORL);
   end;
 end;
 
 procedure TMOS6502.NMI;
 begin
   SET_BREAK(false);
-  StackPush((Pc shr 8) and $FF);
-  StackPush(Pc and $FF);
-  StackPush(Status);
+  StackPush((FPC shr 8) and $FF);
+  StackPush(FPC and $FF);
+  StackPush(FStatus);
   SET_INTERRUPT(True);
-  Pc := (Read(NMIVECTORH) shl 8) + Read(NMIVECTORL);
+  FPC := (FBusReadEvent(NMIVECTORH) shl 8) + FBusReadEvent(NMIVECTORL);
 end;
 
 procedure TMOS6502.Step;
+(*
 var
   Opcode: Byte;
   Instr: PInstr;
   Src: Word;
 begin
   // fetch
-  Opcode := Read(Pc);
-  {$R-}Inc(Pc);{$R+}
+  Opcode := FBusRead(FPC);
+  {$R-}Inc(FPC);{$R+}
 
   // decode and execute
   Instr := @InstrTable[Opcode];
   Src := Instr.Addr;
   Instr.Code(Src);
 
-  Inc(Cycles);
+  Inc(FCycles);
+end;
+*)
+var
+  cc : UInt64;
+begin
+  cc := 0;
+  Run(1,cc,INST_COUNT);
+end;
+
+procedure TMOS6502.Run(Cycles: Cardinal; var CycleCount: UInt64;
+  CycleMethod: TCycleMethod);
+var
+  Opcode: Byte;
+  Instr: PInstr;
+  CyclesRemaining : Cardinal;
+  i : Integer;
+begin
+  CyclesRemaining := Cycles;
+  while(CyclesRemaining > 0) and (not FIllegalOpcode) do
+  begin
+    // fetch
+    Opcode := FBusReadEvent(FPC);
+    {$R-}Inc(FPC);{$R+}
+
+    // decode and execute
+    Instr := @InstrTable[Opcode];
+    Exec(Instr^);
+    {$R-}
+      FCycles := FCycles + Instr^.cycles;
+      CycleCount := CycleCount + Instr^.cycles;
+    {$R+}
+    if CycleMethod = CYCLE_COUNT then
+    begin
+      if CyclesRemaining >= Instr^.cycles then
+        CyclesRemaining := CyclesRemaining - Instr^.cycles
+      else
+        CyclesRemaining := 0;
+    end
+    else
+      Dec(CyclesRemaining);
+    if Assigned(FClockCycleEvent) then
+    begin
+      for i := 0 to Instr^.cycles-1 do
+        FClockCycleEvent(Self);
+    end;
+  end;
+end;
+
+
+procedure TMOS6502.RunEternally;
+var
+  Opcode: Byte;
+  Instr: PInstr;
+  i : Integer;
+begin
+  while (not FIllegalOpcode) do
+  begin
+    // fetch
+    Opcode := FBusReadEvent(FPC);
+    {$R-}Inc(FPC);{$R+}
+
+    // decode and execute
+    Instr := @InstrTable[Opcode];
+    Exec(Instr^);
+    {$R-}FCycles := FCycles + Instr^.cycles;{$R+}
+    if Assigned(FClockCycleEvent) then
+    begin
+      for i := 0 to Instr^.cycles-1 do
+        FClockCycleEvent(Self);
+    end;
+  end;
 end;
 
 procedure TMOS6502.Op_ILLEGAL(Src: Word);
 begin
-  IllegalOpcode := true;
+  FIllegalOpcode := true;
 end;
 
 procedure TMOS6502.Op_AND(Src: Word);
@@ -1072,55 +1355,55 @@ var
   M: Byte;
   Res: Byte;
 begin
-  M := Read(Src);
-  Res := M and A;
+  M := FBusReadEvent(Src);
+  Res := M and FA;
   SET_NEGATIVE((Res and $80) <> 0);
   SET_ZERO(Res = 0);
-  A := Res;
+  FA := Res;
 end;
 
 procedure TMOS6502.Op_ASL(Src: Word);
 var
   M: Byte;
 begin
-  M := Read(Src);
+  M := FBusReadEvent(Src);
   SET_CARRY((M and $80) <> 0);
   {$R-}M := M shl 1;{$R+}
   M := M and $FF;
   SET_NEGATIVE((M and $80) <> 0);
   SET_ZERO(M = 0);
-  Write(Src, M);
+  FBusWriteEvent(Src, M);
 end;
 
 procedure TMOS6502.Op_ASL_ACC(Src: Word);
 var
   M: Byte;
 begin
-  M := A;
+  M := FA;
   SET_CARRY((M and $80) <> 0);
   {$R-}M := M shl 1;{$R+}
   M := M and $FF;
   SET_NEGATIVE((M and $80) <> 0);
   SET_ZERO(M = 0);
-  A := M;
+  FA := M;
 end;
 
 procedure TMOS6502.Op_BCC(Src: Word);
 begin
   if IF_CARRY = 0 then
-    Pc := Src;
+    FPC := Src;
 end;
 
 procedure TMOS6502.Op_BCS(Src: Word);
 begin
   if IF_CARRY = 1 then
-    Pc := Src;
+    FPC := Src;
 end;
 
 procedure TMOS6502.Op_BEQ(Src: Word);
 begin
   if IF_ZERO then
-    Pc := Src;
+    FPC := Src;
 end;
 
 procedure TMOS6502.Op_BIT(Src: Word);
@@ -1128,51 +1411,51 @@ var
   M: Byte;
   Res: Byte;
 begin
-  M := Read(Src);
-  Res := M and A;
+  M := FBusReadEvent(Src);
+  Res := M and FA;
   SET_NEGATIVE((Res and $80) <> 0);
-  Status := (Status and $3F) or (M and $C0);
+  FStatus := (FStatus and $3F) or (M and $C0);
   SET_ZERO(Res = 0);
 end;
 
 procedure TMOS6502.Op_BMI(Src: Word);
 begin
   if IF_NEGATIVE then
-    Pc := Src;
+    FPC := Src;
 end;
 
 procedure TMOS6502.Op_BNE(Src: Word);
 begin
   if not (IF_ZERO) then
-    Pc := Src;
+    FPC := Src;
 end;
 
 procedure TMOS6502.Op_BPL(Src: Word);
 begin
   if not (IF_NEGATIVE) then
-    Pc := Src;
+    FPC := Src;
 end;
 
 procedure TMOS6502.Op_BRK(Src: Word);
 begin
-  Inc(Pc);
-  StackPush((Pc shr 8) and $FF);
-  StackPush(Pc and $FF);
-  StackPush(Status or BREAK_FLAG);
+  Inc(FPC);
+  StackPush((FPC shr 8) and $FF);
+  StackPush(FPC and $FF);
+  StackPush(FStatus or BREAK_CMD);
   SET_INTERRUPT(True);
-  Pc := (Read(IRQVECTORH) shl 8) + Read(IRQVECTORL);
+  FPC := (FBusReadEvent(IRQVECTORH) shl 8) + FBusReadEvent(IRQVECTORL);
 end;
 
 procedure TMOS6502.Op_BVC(Src: Word);
 begin
   if not (IF_OVERFLOW) then
-    Pc := Src;
+    FPC := Src;
 end;
 
 procedure TMOS6502.Op_BVS(Src: Word);
 begin
   if IF_OVERFLOW then
-    Pc := Src;
+    FPC := Src;
 end;
 
 procedure TMOS6502.Op_CLC(Src: Word);
@@ -1199,7 +1482,7 @@ procedure TMOS6502.Op_CMP(Src: Word);
 var
   Tmp: Cardinal;
 begin
-  {$R-}Tmp := A - Read(Src);{$R+}
+  {$R-}Tmp := FA - FBusReadEvent(Src);{$R+}
   SET_CARRY(Tmp < $100);
   SET_NEGATIVE((Tmp and $80) <> 0);
   SET_ZERO((Tmp and $FF)=0);
@@ -1209,7 +1492,7 @@ procedure TMOS6502.Op_CPX(Src: Word);
 var
   Tmp: Cardinal;
 begin
-  {$R-}Tmp := X - Read(Src);{$R+}
+  {$R-}Tmp := FX - FBusReadEvent(Src);{$R+}
   SET_CARRY(Tmp < $100);
   SET_NEGATIVE((Tmp and $80) <> 0);
   SET_ZERO((Tmp and $FF)=0);
@@ -1219,7 +1502,7 @@ procedure TMOS6502.Op_CPY(Src: Word);
 var
   Tmp: Cardinal;
 begin
-  {$R-}Tmp := Y - Read(Src);{$R+}
+  {$R-}Tmp := FY - FBusReadEvent(Src);{$R+}
   SET_CARRY(Tmp < $100);
   SET_NEGATIVE((Tmp and $80) <> 0);
   SET_ZERO((Tmp and $FF)=0);
@@ -1229,144 +1512,144 @@ procedure TMOS6502.Op_DEC(Src: Word);
 var
   M: Byte;
 begin
-  M := Read(Src);
+  M := FBusReadEvent(Src);
   {$R-}M := M - 1;{$R+}
   SET_NEGATIVE((M and $80) <> 0);
   SET_ZERO(M = 0);
-  Write(Src, M);
+  FBusWriteEvent(Src, M);
 end;
 
 procedure TMOS6502.Op_DEX(Src: Word);
 var
   M: Byte;
 begin
-  M := X;
+  M := FX;
   {$R-}M := M - 1;{$R+}
   SET_NEGATIVE((M and $80) <> 0);
   SET_ZERO(M = 0);
-  X := M;
+  FX := M;
 end;
 
 procedure TMOS6502.Op_DEY(Src: Word);
 var
   M: Byte;
 begin
-  M := Y;
+  M := FY;
   {$R-}M := M - 1;{$R+}
   SET_NEGATIVE((M and $80) <> 0);
   SET_ZERO(M = 0);
-  Y := M;
+  FY := M;
 end;
 
 procedure TMOS6502.Op_EOR(Src: Word);
 var
   M: Byte;
 begin
-  M := Read(Src);
-  {$R-}M := A xor M;{$R+}
+  M := FBusReadEvent(Src);
+  {$R-}M := FA xor M;{$R+}
   SET_NEGATIVE((M and $80) <> 0);
   SET_ZERO(M = 0);
-  A := M;
+  FA := M;
 end;
 
 procedure TMOS6502.Op_INC(Src: Word);
 var
   M: Byte;
 begin
-  M := Read(Src);
+  M := FBusReadEvent(Src);
   {$R-}M := M + 1;{$R+}
   SET_NEGATIVE((M and $80) <> 0);
   SET_ZERO(M = 0);
-  Write(Src, M);
+  FBusWriteEvent(Src, M);
 end;
 
 procedure TMOS6502.Op_INX(Src: Word);
 var
   M: Byte;
 begin
-  M := X;
+  M := FX;
   {$R-}M := M + 1;{$R+}
   SET_NEGATIVE((M and $80) <> 0);
   SET_ZERO(M = 0);
-  X := M;
+  FX := M;
 end;
 
 procedure TMOS6502.Op_INY(Src: Word);
 var
   M: Byte;
 begin
-  M := Y;
+  M := FY;
   {$R-}M := M + 1;{$R+}
   SET_NEGATIVE((M and $80) <> 0);
   SET_ZERO(M = 0);
-  Y := M;
+  FY := M;
 end;
 
 procedure TMOS6502.Op_JMP(Src: Word);
 begin
-  Pc := Src;
+  FPC := Src;
 end;
 
 procedure TMOS6502.Op_JSR(Src: Word);
 begin
-  Dec(Pc);
-  StackPush((Pc shr 8) and $FF);
-  StackPush(Pc and $FF);
-  Pc := Src;
+  Dec(FPC);
+  StackPush((FPC shr 8) and $FF);
+  StackPush(FPC and $FF);
+  FPC := Src;
 end;
 
 procedure TMOS6502.Op_LDA(Src: Word);
 var
   M: Byte;
 begin
-  M := Read(Src);
+  M := FBusReadEvent(Src);
   SET_NEGATIVE((M and $80) <> 0);
   SET_ZERO(M = 0);
-  A := M;
+  FA := M;
 end;
 
 procedure TMOS6502.Op_LDX(Src: Word);
 var
   M: Byte;
 begin
-  M := Read(Src);
+  M := FBusReadEvent(Src);
   SET_NEGATIVE((M and $80) <> 0);
   SET_ZERO(M = 0);
-  X := M;
+  FX := M;
 end;
 
 procedure TMOS6502.Op_LDY(Src: Word);
 var
   M: Byte;
 begin
-  M := Read(Src);
+  M := FBusReadEvent(Src);
   SET_NEGATIVE((M and $80) <> 0);
   SET_ZERO(M = 0);
-  Y := M;
+  FY := M;
 end;
 
 procedure TMOS6502.Op_LSR(Src: Word);
 var
   M: Byte;
 begin
-  M := Read(Src);
+  M := FBusReadEvent(Src);
   SET_CARRY((M and $01) <> 0);
   M := M shr 1;
   SET_NEGATIVE(False);
   SET_ZERO(M = 0);
-  Write(Src, M);
+  FBusWriteEvent(Src, M);
 end;
 
 procedure TMOS6502.Op_LSR_ACC(Src: Word);
 var
   M: Byte;
 begin
-  M := A;
+  M := FA;
   SET_CARRY((M and $01) <> 0);
   M := M shr 1;
   SET_NEGATIVE(False);
   SET_ZERO(M = 0);
-  A := M;
+  FA := M;
 end;
 
 procedure TMOS6502.Op_NOP(Src: Word);
@@ -1378,33 +1661,33 @@ procedure TMOS6502.Op_ORA(Src: Word);
 var
   M: Byte;
 begin
-  M := Read(Src);
-  M := A or M;
+  M := FBusReadEvent(Src);
+  M := FA or M;
   SET_NEGATIVE((M and $80) <> 0);
   SET_ZERO(M = 0);
-  A := M;
+  FA := M;
 end;
 
 procedure TMOS6502.Op_PHA(Src: Word);
 begin
-  StackPush(A);
+  StackPush(FA);
 end;
 
 procedure TMOS6502.Op_PHP(Src: Word);
 begin
-  StackPush(Status or BREAK_FLAG);
+  StackPush(FStatus or BREAK_CMD);
 end;
 
 procedure TMOS6502.Op_PLA(Src: Word);
 begin
-  A := StackPop;
-  SET_NEGATIVE((A and $80) <> 0);
-  SET_ZERO(A = 0);
+  FA := StackPop;
+  SET_NEGATIVE((FA and $80) <> 0);
+  SET_ZERO(FA = 0);
 end;
 
 procedure TMOS6502.Op_PLP(Src: Word);
 begin
-  Status := StackPop;
+  FStatus := StackPop;
   SET_CONSTANT(True);
 end;
 
@@ -1412,7 +1695,7 @@ procedure TMOS6502.Op_ROL(Src: Word);
 var
   M: Word;
 begin
-  M := Read(Src);
+  M := FBusReadEvent(Src);
   M := M shl 1;
   if IF_CARRY = 1 then
     M := M or $01;
@@ -1420,14 +1703,14 @@ begin
   M := M and $FF;
   SET_NEGATIVE((M and $80) <> 0);
   SET_ZERO(M = 0);
-  Write(Src, M);
+  FBusWriteEvent(Src, M);
 end;
 
 procedure TMOS6502.Op_ROL_ACC(Src: Word);
 var
   M: Word;
 begin
-  M := A;
+  M := FA;
   M := M shl 1;
   if IF_CARRY = 1 then
     M := M or $01;
@@ -1435,14 +1718,14 @@ begin
   M := M and $FF;
   SET_NEGATIVE((M and $80) <> 0);
   SET_ZERO(M = 0);
-  A := M;
+  FA := M;
 end;
 
 procedure TMOS6502.Op_ROR(Src: Word);
 var
   M: Word;
 begin
-  M := Read(Src);
+  M := FBusReadEvent(Src);
   if IF_CARRY = 1 then
     M := M or $100;
   SET_CARRY((M and $01) <> 0);
@@ -1450,14 +1733,14 @@ begin
   M := M and $FF;
   SET_NEGATIVE((M and $80) <> 0);
   SET_ZERO(M = 0);
-  Write(Src, M);
+  FBusWriteEvent(Src, M);
 end;
 
 procedure TMOS6502.Op_ROR_ACC(Src: Word);
 var
   M: Word;
 begin
-  M := A;
+  M := FA;
   if IF_CARRY = 1 then
     M := M or $100;
     SET_CARRY((M and $01) <> 0);
@@ -1465,19 +1748,19 @@ begin
   M := M and $FF;
   SET_NEGATIVE((M and $80) <> 0);
   SET_ZERO(M = 0);
-  A := M;
+  FA := M;
 end;
 
 procedure TMOS6502.Op_RTI(Src: Word);
 var
   Lo, Hi: Byte;
 begin
-  Status := StackPop;
+  FStatus := StackPop;
 
   Lo := StackPop;
   Hi := StackPop;
 
-  Pc := (Hi shl 8) or Lo;
+  FPC := (Hi shl 8) or Lo;
 end;
 
 procedure TMOS6502.Op_RTS(Src: Word);
@@ -1487,7 +1770,7 @@ begin
   Lo := StackPop;
   Hi := StackPop;
 
-  Pc := (Hi shl 8) or Lo + 1;
+  FPC := (Hi shl 8) or Lo + 1;
 end;
 
 procedure TMOS6502.Op_ADC(Src: Word);
@@ -1495,19 +1778,19 @@ var
   M: Byte;
   Tmp: Cardinal;
 begin
-  M := Read(Src);
-  Tmp := M + A + IF_CARRY;
+  M := FBusReadEvent(Src);
+  Tmp := M + FA + IF_CARRY;
 
   SET_ZERO((Tmp and $FF)=0);
 
   if IF_DECIMAL then
   begin
-    if (((A and $F) + (M and $F) + IF_CARRY) > 9) then
+    if (((FA and $F) + (M and $F) + IF_CARRY) > 9) then
       Tmp := Tmp + 6;
 
     SET_NEGATIVE((Tmp and $80) <> 0);
 
-    SET_OVERFLOW( (((A xor M) and $80) = 0) and (((A xor Tmp) and $80) <> 0));
+    SET_OVERFLOW( (((FA xor M) and $80) = 0) and (((FA xor Tmp) and $80) <> 0));
 
     if Tmp > $99 then
       Tmp := Tmp + $60;
@@ -1517,11 +1800,11 @@ begin
   else
   begin
     SET_NEGATIVE((Tmp and $80) <> 0);
-    SET_OVERFLOW( (((A xor M) and $80)=0) and (((A xor Tmp) and $80) <> 0));
+    SET_OVERFLOW( (((FA xor M) and $80)=0) and (((FA xor Tmp) and $80) <> 0));
     SET_CARRY(Tmp > $FF);
   end;
 
-  A := Tmp and $FF;
+  FA := Tmp and $FF;
 end;
 
 
@@ -1530,18 +1813,18 @@ var
   M: Byte;
   Tmp: Word;
 begin
-  M := Read(Src);
-  {$R-}Tmp := A - M - (1-IF_CARRY);{$R+}
+  M := FBusReadEvent(Src);
+  {$R-}Tmp := FA - M - (1-IF_CARRY);{$R+}
 
   SET_NEGATIVE((Tmp and $80) <> 0);
 
   SET_ZERO((Tmp and $FF) = 0);
 
-   SET_OVERFLOW( (((A xor Tmp) and $80) <> 0)  and (((A xor M) and $80) <> 0));
+   SET_OVERFLOW( (((FA xor Tmp) and $80) <> 0)  and (((FA xor M) and $80) <> 0));
 
   if IF_DECIMAL then
   begin
-    if (((A and $0F) - (1-IF_CARRY)) < (M and $0F)) then
+    if (((FA and $0F) - (1-IF_CARRY)) < (M and $0F)) then
       Tmp := Tmp - 6;
 
     if Tmp > $99 then
@@ -1549,7 +1832,7 @@ begin
   end;
 
   SET_CARRY(Tmp < $100);
-  A := (Tmp and $FF);
+  FA := (Tmp and $FF);
 end;
 
 procedure TMOS6502.Op_SEC(Src: Word);
@@ -1569,72 +1852,72 @@ end;
 
 procedure TMOS6502.Op_STA(Src: Word);
 begin
-  Write(Src, A);
+  FBusWriteEvent(Src, FA);
 end;
 
 procedure TMOS6502.Op_STX(Src: Word);
 begin
-  Write(Src, X);
+  FBusWriteEvent(Src, FX);
 end;
 
 procedure TMOS6502.Op_STY(Src: Word);
 begin
-  Write(Src, Y);
+  FBusWriteEvent(Src, FY);
 end;
 
 procedure TMOS6502.Op_TAX(Src: Word);
 var
   M: Byte;
 begin
-  M := A;
+  M := FA;
   SET_NEGATIVE((M and $80) <> 0);
   SET_ZERO(M = 0);
-  X := M;
+  FX := M;
 end;
 
 procedure TMOS6502.Op_TAY(Src: Word);
 var
   M: Byte;
 begin
-  M := A;
+  M := FA;
   SET_NEGATIVE((M and $80) <> 0);
   SET_ZERO(M = 0);
-  Y := M;
+  FY := M;
 end;
 
 procedure TMOS6502.Op_TSX(Src: Word);
 var
   M: Byte;
 begin
-  M := Sp;
+  M := FSP;
   SET_NEGATIVE((M and $80) <> 0);
   SET_ZERO(M = 0);
-  x := M;
+  FX := M;
 end;
 
 procedure TMOS6502.Op_TXA(Src: Word);
 var
   M: Byte;
 begin
-  M := X;
+  M := FX;
   SET_NEGATIVE((M and $80) <> 0);
   SET_ZERO(M = 0);
-  A := M;
+  FA := M;
 end;
 
 procedure TMOS6502.Op_TXS(Src: Word);
 begin
-  Sp := X;
+  FSP := FX;
 end;
 
 procedure TMOS6502.Op_TYA(Src: Word);
 var
   M: Byte;
 begin
-  M := Y;
+  M := FY;
   SET_NEGATIVE((M and $80) <> 0);
   SET_ZERO(M = 0);
-  A := M;
+  FA := M;
 end;
 
 end.

--- a/Source/MOS6502.pas
+++ b/Source/MOS6502.pas
@@ -33,22 +33,23 @@ unit MOS6502;
 
 interface
 
+const
+  // Status bits
+  NEGATIVE_FLAG  = $80;
+  OVERFLOW_FLAG  = $40;
+  CONSTANT       = $20;
+  BREAK_CMD      = $10;
+  DECIMAL_FLAG   = $08;
+  INTERRUPT_FLAG = $04;
+  ZERO_FLAG      = $02;
+  CARRY_FLAG     = $01;
+
 type
 
   { TMOS6502 }
 
   TMOS6502 = class
     const
-      // Status bits
-      NEGATIVE_FLAG  = $80;
-      OVERFLOW_FLAG  = $40;
-      CONSTANT       = $20;
-      BREAK_CMD      = $10;
-      DECIMAL_FLAG   = $08;
-      INTERRUPT_FLAG = $04;
-      ZERO_FLAG      = $02;
-      CARRY_FLAG     = $01;
-
       // IRQ, reset, NMI vectors
       IRQVECTORH: Word = $FFFF;
       IRQVECTORL: Word = $FFFE;
@@ -77,7 +78,7 @@ type
     procedure SET_CONSTANT(const Value: Boolean); inline;
     procedure SET_BREAK(const Value: Boolean); inline;
     procedure SET_DECIMAL(const Value: Boolean); inline;
-    procedure SET_INTERRUPT(const Value: Boolean); inline;
+    procedure SET_INTERRUPT(const Value: Boolean);// inline;
     procedure SET_ZERO(const Value: Boolean); inline;
     procedure SET_CARRY(const Value: Boolean); inline;
     function IF_NEGATIVE: Boolean; inline;
@@ -187,7 +188,7 @@ type
 
   protected
     // consumed clock cycles
-    FCycles: Cardinal;
+    FCycles: UInt64;
 
     InstrTable: Array [0 .. 255] of TInstr;
 
@@ -252,7 +253,7 @@ type
     property ResetSP : Byte read FResetSP write FResetSP;
     property ResetStatus : Byte read FResetStatus write FResetStatus;
     property IllegalOpcode: Boolean read FIllegalOpcode write FIllegalOpcode;
-
+    property Cycles : UInt64 read FCycles;
   end;
 
 implementation
@@ -1820,7 +1821,7 @@ begin
 
   SET_ZERO((Tmp and $FF) = 0);
 
-   SET_OVERFLOW( (((FA xor Tmp) and $80) <> 0)  and (((FA xor M) and $80) <> 0));
+  SET_OVERFLOW( (((FA xor Tmp) and $80) <> 0)  and (((FA xor M) and $80) <> 0));
 
   if IF_DECIMAL then
   begin

--- a/Source/MOS6502.pas
+++ b/Source/MOS6502.pas
@@ -40,7 +40,7 @@ type
       NEGATIVE = $80;
       OVERFLOW = $40;
       CONSTANT = $20;
-      BREAK = $10;
+      BREAK_FLAG = $10;
       DECIMAL = $08;
       INTERRUPT = $04;
       ZERO = $02;
@@ -767,9 +767,9 @@ end;
 procedure TMOS6502.SET_BREAK(const Value: Boolean);
 begin
   if Value then
-    Status := Status or BREAK
+    Status := Status or BREAK_FLAG
   else
-    Status := Status and (not BREAK);
+    Status := Status and (not BREAK_FLAG);
 end;
 
 procedure TMOS6502.SET_DECIMAL(const Value: Boolean);
@@ -822,7 +822,7 @@ end;
 
 function TMOS6502.IF_BREAK: Boolean;
 begin
-  Result := ((Status and BREAK) <> 0);
+  Result := ((Status and BREAK_FLAG) <> 0);
 end;
 
 function TMOS6502.IF_DECIMAL: Boolean;
@@ -993,7 +993,7 @@ begin
   X := $00;
   Y := $00;
 
-  Status := BREAK or INTERRUPT OR ZERO or CONSTANT;
+  Status := BREAK_FLAG or INTERRUPT OR ZERO or CONSTANT;
   Sp := $FD;
 
   Pc := (Read(RSTVECTORH) shl 8) + Read(RSTVECTORL); // load PC from reset vector
@@ -1052,7 +1052,7 @@ var
 begin
   // fetch
   Opcode := Read(Pc);
-  Inc(Pc);
+  {$R-}Inc(Pc);{$R+}
 
   // decode and execute
   Instr := @InstrTable[Opcode];
@@ -1158,7 +1158,7 @@ begin
   Inc(Pc);
   StackPush((Pc shr 8) and $FF);
   StackPush(Pc and $FF);
-  StackPush(Status or BREAK);
+  StackPush(Status or BREAK_FLAG);
   SET_INTERRUPT(True);
   Pc := (Read(IRQVECTORH) shl 8) + Read(IRQVECTORL);
 end;
@@ -1392,7 +1392,7 @@ end;
 
 procedure TMOS6502.Op_PHP(Src: Word);
 begin
-  StackPush(Status or BREAK);
+  StackPush(Status or BREAK_FLAG);
 end;
 
 procedure TMOS6502.Op_PLA(Src: Word);

--- a/Testsuite/Source/TestSuite.dpr
+++ b/Testsuite/Source/TestSuite.dpr
@@ -1,11 +1,19 @@
 program TestSuite;
 
+{$IFDEF FPC}
+  {$MODE Delphi}
+{$ENDIF}
+
 {$APPTYPE CONSOLE}
 
-{$R *.res}
+{.$R *.res}
 
 uses
+{$IFnDEF FPC}
   System.Classes, System.SysUtils,
+{$ELSE}
+  Classes, SysUtils,
+{$ENDIF}
   MOS6502 in '..\..\Source\MOS6502.pas';
 
 type
@@ -86,13 +94,18 @@ end;
 
 var
   MOS6502: TMOS6502TestSuite;
-
+  fp : String;
 begin
   try
     MOS6502 := TMOS6502TestSuite.Create;
     try
       // load test bin
-      MOS6502.Load('..\Test-Files\6502_functional_test.bin');
+      fp := '..\Test-Files\';
+      {$IFDEF FPC}
+        fp :=  '..\..\'+ fp;
+      {$ENDIF}
+
+      MOS6502.Load(fp+'6502_functional_test.bin');
 
       // set reset vectors to $0400
       MOS6502.Memory[$FFFC] := 0;

--- a/VIC-20/Source/FormV20.pas
+++ b/VIC-20/Source/FormV20.pas
@@ -63,6 +63,8 @@ begin
 
   VC20 := TVC20.Create;
   VC20.WndHandle := Handle;
+  // Call for 3K RAM extension installed, comment if default ram should be used
+  VC20.Add3KRAMExt;
   fp := IncludeTrailingPathDelimiter(ExtractFilePath(Application.ExeName));
   {$IFDEF FPC}
   fp := fp + '..\..\';

--- a/VIC-20/Source/VIC20.pas
+++ b/VIC-20/Source/VIC20.pas
@@ -132,7 +132,7 @@ type
     function GetMemKind(AMemAddr : Word) : TVC20MemKind;
   protected
     KeyMatrix: Array[0 .. 7, 0 .. 7] of Byte;
-    Memory: PByte;
+    Memory: array of Byte;
     InterruptRequest: Boolean;
     procedure SetupMemoryMap;virtual;
     function GetMemoryMapItemCount : Integer;
@@ -171,7 +171,7 @@ var
 begin
   VC20 := TVC20(dwUser);
 
-  if VC20.Status and VC20.INTERRUPT_FLAG = 0 then // if IRQ allowed then set irq
+  if VC20.Status and INTERRUPT_FLAG = 0 then // if IRQ allowed then set irq
     VC20.InterruptRequest := True;
 end;
 
@@ -223,7 +223,7 @@ begin
   inherited Create(OnBusRead, OnBusWrite);
 
   // create 64kB memory table
-  GetMem(Memory, 65536);
+  SetLength(Memory, 65536);
 
   SetupMemoryMap;
 
@@ -237,7 +237,7 @@ begin
   Thread.Terminate;
   Thread.WaitFor;
   Thread.Free;
-  FreeMem(Memory);
+  SetLength(Memory,0);
   inherited;
 end;
 
@@ -255,7 +255,7 @@ begin
   Cols := Memory[CIA1];
   for Col := 0 to 7 do
   begin
-    if Cols and (1 shl Col) = 0 then  // FA 0 indicates FA column FBusRead
+    if Cols and (1 shl Col) = 0 then  // a 0 indicates a column read
     begin
       for Row := 0 to 7 do
       begin


### PR DESCRIPTION
Have look to this update. 
It implements an MemoryMap to allow the usage of optional memory and a simpler "case"-Management on setting memory and getting values from the memory.
On the long end, there is one method, that "insert" the optional 3K RAM, which funny enought leads to the display that the whole implementation has, before I wrote a single line. But it allows now to simulate the default "3583 Bytes free".

I had a short look into the new c++ code of the 6502 emulation. The changes are not direct compatible, since the method "step" is replaced by "run" etc. I am not sure if I find time to go through this implementation.

I am surprised that the high-resolution graphic features are not implemented, as well that the character ROM is not used. But maybe that beyond what the original idea behind this small project was.

Greetings Ekkehard