### PR TITLE
6502 Cycles / Run / etc. update, Timing of thread and internal IRQ

### DIFF
--- a/VIC-20/ROMs/README.md
+++ b/VIC-20/ROMs/README.md
@@ -1,1 +1,12 @@
 Put your BASIC and Kernal ROMs here
+Download is available her:
+https://www.commodore.ca/manuals/funet/cbm/firmware/computers/vic20/
+    VIC-20 parts and firmware versions
+basic.901486-01.bin
+    Commodore VIC-20 BASIC V2. The first and only version.
+characters.901460-03.bin
+    Commodore VIC-20 character generator ROM.
+kernal.901486-06.bin
+    Commodore VIC-20 KERNAL ROM, revision 6. Intended for NTSC-M systems. Probably not the first revision. But not the sixth revision either, since the BASIC ROM has the same part number.
+kernal.901486-07.bin
+    Commodore VIC-20 KERNAL ROM, revision 7. Intended for PAL-B systems. Probably the last revision.

--- a/VIC-20/Source/FormV20.pas
+++ b/VIC-20/Source/FormV20.pas
@@ -70,7 +70,14 @@ begin
   fp := fp + '..\..\';
   {$ENDIF}
 
-  VC20.LoadROM(fp+'..\ROMs\kernal.901486-07.bin', $E000); // E000-FFFF
+  // NTSC Firmware
+  VC20.LoadROM(fp+'..\ROMs\kernal.901486-06.bin', $E000); // E000-FFFF
+  // PAL Firmware
+  // If the PAL firmware is used, you must tell the system the usage of PAL!!
+  // VC20.LoadROM(fp+'..\ROMs\kernal.901486-07.bin', $E000); // E000-FFFF
+  // VC20.SetSysFreq(fkPAL);
+
+
   VC20.LoadROM(fp+'..\ROMs\basic.901486-01.bin', $C000); // C000-DFFF
   VC20.LoadROM(fp+'..\ROMs\characters.901460-03.bin', $8000); // 8000-8FFF
   VC20.Exec;


### PR DESCRIPTION
I updated the MOS6520.pas according to the *.c source. In my oppinion the cycles fields are missing in the IRQ/NMI/Push/Pop and MemRead and Write functions. This is not added now.
I implemented a much better timing behaviour in the thread, running with both PAL and NTSC firmware.
I implemented also an internal method to execute the IRQ by using the cycles counter and the value from the VIA timer register. This is more precise than using an external timer and allows the VIA register change by the user program.
Take a look if the might fit into the project.

To validate the timing you may use the following basic line. In command mode enter
`?TI$`
than hit enter and start a stop watch. The VIC-20 will print something like "000022" which says that the system is up and running for 00h, 00m and 22s
Enter the command again and wait until you stopwatch shows that one minute is gone.
The display should show "000122", telling that one minute is gone. 